### PR TITLE
Fix on page change at FlutterFlowCalendar

### DIFF
--- a/lib/src/flutter_flow/flutter_flow_calendar.dart
+++ b/lib/src/flutter_flow/flutter_flow_calendar.dart
@@ -189,6 +189,9 @@ class _FlutterFlowCalendarState extends State<FlutterFlowCalendar> {
                 }
               }
             },
+            onPageChanged: (newFocusedDay) {
+              setState(() => focusedDay = newFocusedDay);
+            },
           ),
         ],
       );


### PR DESCRIPTION
Now month and year in the calendar header is updated on swiping the calendar body